### PR TITLE
fix: OpenVidu 세션 중복 연결 방지 및 소켓 처리 개선 #124

### DIFF
--- a/app/_components/Video/Video.tsx
+++ b/app/_components/Video/Video.tsx
@@ -31,6 +31,9 @@ const Video: React.FC<Props> = ({
   const [currentPage, setCurrentPage] = useState(0);
   const currentPublisherRef = useRef<any>(null);
 
+  // Ref to track if initializeSession has already been called
+  const sessionInitializedRef = useRef(false);
+
   const handlerJoinSessionEvent = () => {
     console.log("Join session");
   };
@@ -44,7 +47,7 @@ const Video: React.FC<Props> = ({
         session.disconnect();
         setSession(undefined);
         setSubscribers([]);
-        socket.disconnect();
+        // socket.disconnect(); // end_meeting이 대신 처리함
         router.push(url);
       }
     };
@@ -54,7 +57,7 @@ const Video: React.FC<Props> = ({
     return () => {
       socket.off("end_meeting", handleRoomId);
     };
-  }, [session, subscriber, socket, router])
+  }, [session, subscriber, socket, router]);
 
   const handlerLeaveSessionEvent = useCallback(() => {
     socket.emit("end_meeting", sessionId);
@@ -66,6 +69,13 @@ const Video: React.FC<Props> = ({
   };
 
   const initializeSession = async (token: string) => {
+    // 한번만 실행되도록 수정
+    if (sessionInitializedRef.current) {
+      return;
+    }
+    sessionInitializedRef.current = true;
+    
+    console.log("initializeSession called");
     const openvidu = new OpenVidu();
     const mySession = openvidu.initSession();
     openvidu.setAdvancedConfiguration({
@@ -181,6 +191,7 @@ const Video: React.FC<Props> = ({
   };
 
   useEffect(() => {
+    console.log("token: ", token);
     if (token) {
       initializeSession(token);
     }


### PR DESCRIPTION
- OpenVidu 세션이 한 번만 연결되도록 수정하여 에러 방지
- 서버에서 소켓 연결을 이미 끊기 때문에 중복된 socket.disconnect() 제거
close #124 